### PR TITLE
Header definition changes for clang

### DIFF
--- a/test/test_icuutil.cpp
+++ b/test/test_icuutil.cpp
@@ -16,11 +16,11 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include "pair_out.h"
 #include <scope/test.h>
 
 #include "rangeset.h"
 #include "icuutil.h"
-#include "pair_out.h"
 
 #include <unicode/uset.h>
 #include <memory>

--- a/test/test_parseutil.cpp
+++ b/test/test_parseutil.cpp
@@ -16,13 +16,13 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include "pair_out.h"
 #include <scope/test.h>
 
 #include <sstream>
 
 #include "basic.h"
 #include "parseutil.h"
-#include "pair_out.h"
 
 SCOPE_TEST(parseHexCharTest) {
   // good

--- a/test/test_unicode.cpp
+++ b/test/test_unicode.cpp
@@ -24,6 +24,7 @@
 #include <iomanip>
 #include <iostream>
 #include <type_traits>
+#include <vector>
 
 #include "basic.h"
 #include "unicode.h"


### PR DESCRIPTION
When running `make check`, clang is much fussier about the order of header includes than gcc is. It complains about the use of `operator<<` in scope/test when both  scope/test.h and pair_out.h are included in a couple of test source files. It discovers the use of pair_out.h's `operator<<` in the test's use of a scope/test function, but scope/test is included before pair_out.h, so it complains that that definition of `operator<<` is in the wrong place. It seems to be in the family of issues detailed at http://clang.llvm.org/compatibility.html#dep_lookup. 

Also, in one file, a std::vector was used without `#include <vector>`. I don't know how gcc was compiling that.